### PR TITLE
Fixed incorrect line numbers after mutiline comments and verbatim strings.

### DIFF
--- a/pmd-cs/src/main/java/net/sourceforge/pmd/cpd/CsTokenizer.java
+++ b/pmd-cs/src/main/java/net/sourceforge/pmd/cpd/CsTokenizer.java
@@ -102,6 +102,7 @@ public class CsTokenizer implements Tokenizer {
                 // strings & chars
                 case '"':
                 case '\'':
+                    int beginLine = line;
                     b = new StringBuilder();
                     b.append(c);
                     while ((ic = reader.read()) != c) {
@@ -113,13 +114,19 @@ public class CsTokenizer implements Tokenizer {
                             int next = reader.read();
                             if (next != -1) {
                                 b.append((char) next);
+
+                                if (next == '\n') {
+                                    line++;
+                                }
                             }
+                        } else if (ic == '\n') {
+                            line++;
                         }
                     }
                     if (ic != -1) {
                         b.append((char) ic);
                     }
-                    tokenEntries.add(new TokenEntry(b.toString(), sourceCode.getFileName(), line));
+                    tokenEntries.add(new TokenEntry(b.toString(), sourceCode.getFileName(), beginLine));
                     ic = reader.read();
                     break;
 
@@ -127,6 +134,7 @@ public class CsTokenizer implements Tokenizer {
                 case '/':
                     switch (c = (char) (ic = reader.read())) {
                     case '*':
+                        //int beginLine = line;
                         int state = 1;
                         b = new StringBuilder();
                         b.append("/*");
@@ -134,6 +142,10 @@ public class CsTokenizer implements Tokenizer {
                         while ((ic = reader.read()) != -1) {
                             c = (char) ic;
                             b.append(c);
+
+                            if (c == '\n') {
+                                line++;
+                            }
 
                             if (state == 1) {
                                 if (c == '*') {
@@ -150,7 +162,7 @@ public class CsTokenizer implements Tokenizer {
                         }
                         // ignore the /* comment
                         // tokenEntries.add(new TokenEntry(b.toString(),
-                        // sourceCode.getFileName(), line));
+                        // sourceCode.getFileName(), beginLine));
                         break;
 
                     case '/':

--- a/pmd-cs/src/test/java/net/sourceforge/pmd/cpd/CsTokenizerTest.java
+++ b/pmd-cs/src/test/java/net/sourceforge/pmd/cpd/CsTokenizerTest.java
@@ -105,6 +105,39 @@ public class CsTokenizerTest {
 	assertEquals(50, tokens.size());
     }
 
+    @Test
+    public void testLineNumberAfterMultilineComment() {
+	tokenizer.tokenize(toSourceCode(
+		"/* This is a multiline comment \n"
+			+ " * \n"
+			+ " * Lorem ipsum dolor sit amet, \n"
+			+ " * consectetur adipiscing elit \n"
+			+ " */\n"
+			+ "\n"
+			+ "class Foo {\n"
+			+ "\n"
+			+ "}"
+		), tokens);
+	assertEquals(5, tokens.size());
+	assertEquals(7, tokens.getTokens().get(0).getBeginLine());
+    }
+
+    @Test
+    public void testLineNumberAfterMultilineString() {
+	tokenizer.tokenize(toSourceCode(
+		"class Foo {\n"
+			+ "  void bar() {\n"
+			+ "    String query = \n"
+			+ "      @\"SELECT foo, bar\n"
+			+ "         FROM table \n"
+			+ "         WHERE id = 42\"; \n"
+			+ "  }\n"
+			+ "}"
+		), tokens);
+	assertEquals(16, tokens.size());
+	assertEquals(8, tokens.getTokens().get(14).getBeginLine());
+    }
+
     private SourceCode toSourceCode(String source) {
 	return new SourceCode(new SourceCode.StringCodeLoader(source));
     }


### PR DESCRIPTION
The line number after multiline comments and verbatim strings  was incorrect, because the line number was not increased when a multiline comment of verbatim strings contains a newline character ("\n").