### PR TITLE
Fixed '--files' command line option of CPD, so it also works for files and not only for directories.

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPD.java
@@ -53,11 +53,11 @@ public class CPD {
         return matchAlgorithm.matches();
     }
 
-    public void addAllInDirectory(String dir) throws IOException {
+    public void addAllInDirectory(File dir) throws IOException {
         addDirectory(dir, false);
     }
 
-    public void addRecursively(String dir) throws IOException {
+    public void addRecursively(File dir) throws IOException {
         addDirectory(dir, true);
     }
 
@@ -67,8 +67,8 @@ public class CPD {
         }
     }
 
-    private void addDirectory(String dir, boolean recurse) throws IOException {
-        if (!(new File(dir)).exists()) {
+    private void addDirectory(File dir, boolean recurse) throws IOException {
+        if (!dir.exists()) {
             throw new FileNotFoundException("Couldn't find directory " + dir);
         }
         FileFinder finder = new FileFinder();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
@@ -3,6 +3,9 @@
  */
 package net.sourceforge.pmd.cpd;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -73,7 +76,7 @@ public class CPDCommandLineInterface {
                 //Add files 
                 if ( null != arguments.getFiles() && ! arguments.getFiles().isEmpty() )
                 {
-                  addSourcesFilesToCPD(arguments.getFiles(),cpd, !arguments.isNonRecursive());
+                  addSourcesFilesToCPD(arguments.getFiles(), arguments.filenameFilter(), cpd, !arguments.isNonRecursive());
                 }
 
                 //Add Database URIS
@@ -89,14 +92,27 @@ public class CPDCommandLineInterface {
 		}
 	}
 
-	private static void addSourcesFilesToCPD(List<String> files, CPD cpd, boolean recursive) {
+	private static void addSourcesFilesToCPD(List<File> files, FilenameFilter filter, CPD cpd, boolean recursive) {
 		try {
-			for (String file : files)
-				if (recursive) {
-					cpd.addRecursively(file);
+			for (File file : files) {
+				if (!file.exists()) {
+					throw new FileNotFoundException("Couldn't find directory/file '" + file + "'");
+				} else if (file.isDirectory()) {
+					if (recursive) {
+						cpd.addRecursively(file);
+					} else {
+						cpd.addAllInDirectory(file);
+					}
 				} else {
-					cpd.addAllInDirectory(file);
+					//Add a single file if it is accepted by the file filter
+					File directory = file.getAbsoluteFile().getParentFile();
+					String filename = file.getName();
+
+					if (filter.accept(directory, filename)) {
+						cpd.add(file);
+					}
 				}
+			}
 		} catch (IOException e) {
 			throw new IllegalStateException(e);
 		}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.util.FileFinder;
 
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.converters.FileConverter;
 
 /**
  *
@@ -69,11 +70,11 @@ public class CPDConfiguration extends AbstractConfiguration {
 	        + "Default is \"" + Tokenizer.DEFAULT_SKIP_BLOCKS_PATTERN + "\".", required = false)
 	private String skipBlocksPattern = Tokenizer.DEFAULT_SKIP_BLOCKS_PATTERN;
 
-	@Parameter(names = "--files", variableArity = true, description = "List of files and directories to process", required = false)
-	private List<String> files;
+	@Parameter(names = "--files", variableArity = true, description = "List of files and directories to process", required = false, converter = FileConverter.class)
+	private List<File> files;
 
-	@Parameter(names = "--exclude", variableArity = true, description = "Files to be excluded from CPD check", required = false)
-	private List<String> excludes;
+	@Parameter(names = "--exclude", variableArity = true, description = "Files to be excluded from CPD check", required = false, converter = FileConverter.class)
+	private List<File> excludes;
 
 	@Parameter(names = "--non-recursive", description = "Don't scan subdirectiories", required = false)
         private boolean nonRecursive;
@@ -245,15 +246,14 @@ public class CPDConfiguration extends AbstractConfiguration {
 
         if (excludes != null) {
             FileFinder finder = new FileFinder();
-            for (String excludedFile : excludes) {
-                File exFile = new File(excludedFile);
-                if (exFile.isDirectory()) {
+            for (File excludedFile : excludes) {
+                if (excludedFile.isDirectory()) {
                     List<File> files = finder.findFilesFrom(excludedFile, languageFilter, true);
                     for (File f : files) {
                         exclusions.add(f.getAbsolutePath());
                     }
                 } else {
-                    exclusions.add(exFile.getAbsolutePath());
+                    exclusions.add(excludedFile.getAbsolutePath());
                 }
             }
         }
@@ -307,11 +307,11 @@ public class CPDConfiguration extends AbstractConfiguration {
 	    this.skipLexicalErrors = skipLexicalErrors;
 	}
 
-	public List<String> getFiles() {
+	public List<File> getFiles() {
 		return files;
 	}
 
-	public void setFiles(List<String> files) {
+	public void setFiles(List<File> files) {
 		this.files = files;
 	}
 
@@ -323,11 +323,11 @@ public class CPDConfiguration extends AbstractConfiguration {
 		this.uri = uri;
 	}
 
-	public List<String> getExcludes() {
+	public List<File> getExcludes() {
 	    return excludes;
 	}
 
-	public void setExcludes(List<String> excludes) {
+	public void setExcludes(List<File> excludes) {
 	    this.excludes = excludes;
 	}
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
@@ -572,9 +572,9 @@ public class GUI implements CPDListener {
     }
 
     private void go() {
-    	String dirPath = rootDirectoryField.getText();
         try {
-            if (!(new File(dirPath)).exists()) {
+            File dirPath = new File(rootDirectoryField.getText());
+            if (!dirPath.exists()) {
                 JOptionPane.showMessageDialog(frame,
                         "Can't read from that root source directory",
                         "Error", JOptionPane.ERROR_MESSAGE);
@@ -602,8 +602,8 @@ public class GUI implements CPDListener {
             cpd.setCpdListener(this);
             tokenizingFilesBar.setMinimum(0);
             phaseLabel.setText("");
-            if (isLegalPath(dirPath, conf)) {	// should use the language file filter instead?
-            	cpd.add(new File(dirPath));
+            if (isLegalPath(dirPath.getPath(), conf)) {	// should use the language file filter instead?
+            	cpd.add(dirPath);
             } else {
                 if (recurseCheckbox.isSelected()) {
                     cpd.addRecursively(dirPath);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/DCD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/DCD.java
@@ -116,7 +116,7 @@ public class DCD {
 		for (int i = 0; i < directories.size(); i++) {
 			File directory = directories.get(i);
 			FilenameFilter filter = filters.get(i);
-			List<File> files = new FileFinder().findFilesFrom(directory.getPath(), filter, true);
+			List<File> files = new FileFinder().findFilesFrom(directory, filter, true);
 			for (File file : files) {
 				String name = file.getPath();
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/FileFinder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/FileFinder.java
@@ -16,10 +16,10 @@ public class FileFinder {
     private FilenameFilter filter;
     private static final String FILE_SEP = System.getProperty("file.separator");
 
-    public List<File> findFilesFrom(String dir, FilenameFilter filter, boolean recurse) {
+    public List<File> findFilesFrom(File dir, FilenameFilter filter, boolean recurse) {
         this.filter = filter;
         List<File> files = new ArrayList<File>();
-        scanDirectory(new File(dir), files, recurse);
+        scanDirectory(dir, files, recurse);
         return files;
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/FileUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/FileUtil.java
@@ -97,7 +97,7 @@ public final class FileUtil {
 		    .getDirectoryFilter(), Filters.toNormalizedFileFilter(Filters.buildRegexFilterExcludeOverInclude(
 		    null, Collections.singletonList("SCCS")))));
 	    FileFinder finder = new FileFinder();
-	    List<File> files = finder.findFilesFrom(file.getAbsolutePath(), Filters.toFilenameFilter(filter), true);
+	    List<File> files = finder.findFilesFrom(file, Filters.toFilenameFilter(filter), true);
 	    for (File f : files) {
 		dataSources.add(new FileDataSource(f));
 	    }


### PR DESCRIPTION
Fixed '--files' command line option of CPD, so it also works for files and not only for directories.

The '--files' command line option of CPD lets you specify which directories and files should be scanned for duplicated code.
Unfortunately it didn't work when you specified files instead of directories, for example: '--files foo.c bar.c'. In this example CPD executed successful, but the files 'foo.c' and 'bar.c' are completely ignored.