### PR TITLE
Fixed exit status of PMD when error occurs

### DIFF
--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -121,5 +121,11 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.8.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -439,7 +439,7 @@ public class PMD {
         } catch (Exception e) {
             System.out.println(PMDCommandLineInterface.buildUsageText());
             System.out.println();
-            System.out.println(e.getMessage());
+            System.err.println(e.getMessage());
             status = PMDCommandLineInterface.ERROR_STATUS;
         } finally {
             logHandlerManager.close();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDCommandLineInterface.java
@@ -41,7 +41,7 @@ public class PMDCommandLineInterface {
 		} catch (ParameterException e) {
 			jcommander.usage();
 			System.out.println(buildUsageText(jcommander));
-			System.out.println(e.getMessage());
+			System.err.println(e.getMessage());
 			setStatusCodeOrExit(ERROR_STATUS);
 		}
 		return arguments;
@@ -174,9 +174,13 @@ public class PMDCommandLineInterface {
 		}
 	}
 
-    private static boolean isExitAfterRunSet() {
-    	return (System.getenv(NO_EXIT_AFTER_RUN) == null ? false : true);
-    }
+	private static boolean isExitAfterRunSet() {
+		String noExit = System.getenv(NO_EXIT_AFTER_RUN);
+		if (noExit == null) {
+			noExit = System.getProperty(NO_EXIT_AFTER_RUN);
+		}
+		return (noExit == null ? true : false);
+	}
 
     private static void setStatusCode(int statusCode) {
     	System.setProperty(STATUS_CODE_PROPERTY, Integer.toString(statusCode));

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
@@ -63,7 +63,7 @@ public class CPDCommandLineInterface {
 		} catch (ParameterException e) {
 			jcommander.usage();
 			System.out.println(buildUsageText());
-			System.out.println(e.getMessage());
+			System.err.println(e.getMessage());
 			setStatusCodeOrExit(1);
 			return;
 		}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -163,7 +163,7 @@ public class CPDConfiguration extends AbstractConfiguration {
 		try {
 			return (Renderer) Class.forName(name).newInstance();
 		} catch (Exception e) {
-			System.out.println("Can't find class '" + name
+			System.err.println("Can't find class '" + name
 					+ "', defaulting to SimpleRenderer.");
 		}
 		return new SimpleRenderer();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cli/PMDCommandLineInterfaceTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cli/PMDCommandLineInterfaceTest.java
@@ -4,12 +4,27 @@
 package net.sourceforge.pmd.cli;
 
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 /**
  * Unit test for {@link PMDCommandLineInterface}
  */
 public class PMDCommandLineInterfaceTest {
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+    @Rule //Restores system properties after test
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+    @Before
+    public void clearSystemProperties () {
+        System.clearProperty(PMDCommandLineInterface.NO_EXIT_AFTER_RUN);
+        System.clearProperty(PMDCommandLineInterface.STATUS_CODE_PROPERTY);
+    }
 
     @Test
     public void testProperties() {
@@ -19,5 +34,20 @@ public class PMDCommandLineInterfaceTest {
         PMDCommandLineInterface.extractParameters(params, args, "PMD");
 
         Assert.assertEquals("output_folder", params.getProperties().getProperty("outputDir"));
+    }
+    
+    @Test
+    public void testSetStatusCodeOrExit_DoExit() {
+        exit.expectSystemExitWithStatus(0);
+
+        PMDCommandLineInterface.setStatusCodeOrExit(0);
+    }
+
+    @Test
+    public void testSetStatusCodeOrExit_SetStatus() {
+        System.setProperty(PMDCommandLineInterface.NO_EXIT_AFTER_RUN, "1");
+
+        PMDCommandLineInterface.setStatusCodeOrExit(0);
+        Assert.assertEquals(System.getProperty(PMDCommandLineInterface.STATUS_CODE_PROPERTY), "0");
     }
 }


### PR DESCRIPTION
When an error occured the exit status of PMD was 0. The error occured
because the logic of 'NO_EXIT_AFTER_RUN' was incorrect/inverted. A
'System.exit()' was performed when 'NO_EXIT_AFTER_RUN' was set while it
should be skipped. I copied the fix from the CPDCommandLineInterface
class.

Furthermore I made sure all error messages are printed to System.err
instead of System.out, so they can easily extracted/found when PMD is
invoked by external tools.