### PR TITLE
Fix misleading spelling in the "m is leading variable name" rule

### DIFF
--- a/pmd-core/src/main/resources/rulesets/releases/34.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/34.xml
@@ -17,7 +17,7 @@ This ruleset contains links to rules that are new in PMD v3.4
 
   <rule ref="rulesets/java/controversial.xml/DefaultPackage"/>
 
-  <rule ref="rulesets/java/naming.xml/MisleadingVariableName"/>
+  <rule ref="rulesets/java/naming.xml/M_IsLeadingVariableName"/>
 
   <rule ref="rulesets/java/migrating.xml/ReplaceVectorWithList"/>
   <rule ref="rulesets/java/migrating.xml/ReplaceHashtableWithMap"/>

--- a/pmd-java/src/main/resources/rulesets/java/naming.xml
+++ b/pmd-java/src/main/resources/rulesets/java/naming.xml
@@ -446,12 +446,12 @@ public class SomeClass {
         </example>
       </rule>
 
-    <rule name="MisleadingVariableName"
+    <rule name="M_IsLeadingVariableName"
    		language="java"
           since="3.4"
           message="Avoid naming non-fields with the prefix 'm_'"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/rules/java/naming.html#MisleadingVariableName">
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/naming.html#M_IsLeadingVariableName">
       <description>
 Detects when a non-field has a name starting with 'm_'.  This usually denotes a field and could be confusing.
       </description>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/naming/NamingRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/naming/NamingRulesTest.java
@@ -20,7 +20,7 @@ public class NamingRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "LongVariable");
         addRule(RULESET, "MethodNamingConventions");
         addRule(RULESET, "MethodWithSameNameAsEnclosingClass");
-        addRule(RULESET, "MisleadingVariableName");
+        addRule(RULESET, "M_IsLeadingVariableName");
         addRule(RULESET, "NoPackage");
         addRule(RULESET, "PackageCase");
         addRule(RULESET, "ShortMethodName");

--- a/src/site/markdown/overview/changelog-old.md
+++ b/src/site/markdown/overview/changelog-old.md
@@ -1543,7 +1543,7 @@ The binary package still contains all languages and can be used as usual. Have a
      Basic ruleset: ClassCastExceptionWithToArray, AvoidDecimalLiteralsInBigDecimalConstructor
      Design ruleset: NonThreadSafeSingleton, UncommentedEmptyMethod, UncommentedEmptyConstructor
      Controversial ruleset: DefaultPackage
-     Naming ruleset: MisleadingVariableName
+     Naming ruleset: M_IsLeadingVariableName
      Migration ruleset: ReplaceVectorWithList, ReplaceHashtableWithMap, ReplaceEnumerationWithIterator, AvoidEnumAsIdentifier, AvoidAssertAsIdentifier
      Strings ruleset: UseStringBufferLength
     Fixed bug 1292745 - Removed unused source file ExceptionTypeChecking.java

--- a/src/site/markdown/overview/credits.md
+++ b/src/site/markdown/overview/credits.md
@@ -210,7 +210,7 @@
 *   Mark Holczhammer - bug report for InefficientStringBuffering
 *   Raja Rajan - 2 bug reports for CompareObjectswithEquals
 *   Jeff Chamblee - suggested better message for UnnecessaryCaseChange, bug report for CompareObjectsWithEquals
-*   Dave Brosius - suggested MisleadingVariableName rule, a couple of nice patches to clean up some string handling
+*   Dave Brosius - suggested M_IsleadingVariableName rule, a couple of nice patches to clean up some string handling
     inefficiencies, non-static class usages, and unclosed streams/readers - found with Findbugs, I daresay :-)
 *   Chris Grindstaff - fixed SWTException when Eclipse plugin is run on a file with syntax error
 *   Eduard Naum - fixed JDK 1.3 runtime problems in Eclipse plugin


### PR DESCRIPTION
@adangel 

There's a PMD setting called "MisleadingVariableName" which is friendly and
checks whether m_ is leading your variable name and lets you know. It was named
somewhat confusingly though, probably by accident; looks like someone left out
the underscore (_) and forgot to put a capital I and L to make the camel case
right. I've fixed this bug.

Should consider extending this functionality, e.g. "A_IsLeadingVariableName,"
"B_IsLeadingVariableName," etc.