### PR TITLE
Extended Objective-C grammar to accept Unicode characters in identifiers

### DIFF
--- a/pmd-objectivec/etc/grammar/ObjC2.0.jj
+++ b/pmd-objectivec/etc/grammar/ObjC2.0.jj
@@ -548,9 +548,19 @@ TOKEN : { <EXPORTED_CALLBACK : "EXPORTED_CALLBACK"> }
 
 TOKEN :
 {
-   < IDENT : <IDENT_NONDIGIT> ( <IDENT_NONDIGIT> | <DIGIT>)* >
+  < IDENT : <IDENT_NONDIGIT> ( <IDENT_NONDIGIT> | <DIGIT>)* >
 | <#IDENT_NONDIGIT : <NONDIGIT> | <UNIVERSAL_CHARACTER_NAME> > // "may include other implementation-defined characters"
-| <#NONDIGIT : ["a"-"z"] | ["A"-"Z"] | "_" | "$" >
+| <#NONDIGIT : ["a"-"z"] | ["A"-"Z"] | "_" | "$" | <NONDIGIT_UNICODE> >
+| <#NONDIGIT_UNICODE : [ /* source: http://stackoverflow.com/questions/30933785 */
+   "\u0024",
+   "\u0041"-"\u005a",
+   "\u005f",
+   "\u0061"-"\u007a",
+   "\u00c0"-"\u00d6",
+   "\u00d8"-"\u00f6",
+   "\u00f8"-"\u00ff",
+   "\u0100"-"\u1fff"
+  ] >
 | <#UNIVERSAL_CHARACTER_NAME : ("\\u" <HEX_QUAD>) | ("\\U" <HEX_QUAD> <HEX_QUAD>) >
 }
 

--- a/pmd-objectivec/src/test/java/net/sourceforge/pmd/cpd/UnicodeObjectiveCTokenizerTest.java
+++ b/pmd-objectivec/src/test/java/net/sourceforge/pmd/cpd/UnicodeObjectiveCTokenizerTest.java
@@ -1,0 +1,37 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+package net.sourceforge.pmd.cpd;
+
+import java.io.IOException;
+
+import net.sourceforge.pmd.testframework.AbstractTokenizerTest;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+
+//Tests if the ObjectiveC tokenizer supports identifiers with unicode characters
+public class UnicodeObjectiveCTokenizerTest extends AbstractTokenizerTest {
+
+    private static final String FILENAME = "NCClient.m";
+
+    @Before
+    @Override
+    public void buildTokenizer() throws IOException {
+        this.tokenizer = new ObjectiveCTokenizer();
+        this.sourceCode = new SourceCode(new SourceCode.StringCodeLoader(this.getSampleCode(), FILENAME));
+    }
+
+    @Override
+    public String getSampleCode() throws IOException {
+        return IOUtils.toString(ObjectiveCTokenizer.class.getResourceAsStream(FILENAME), "UTF-8");
+    }
+
+    @Test
+    public void tokenizeTest() throws IOException {
+        this.expectedTokenCount = 10;
+        super.tokenizeTest();
+    }
+}

--- a/pmd-objectivec/src/test/resources/net/sourceforge/pmd/cpd/NCClient.m
+++ b/pmd-objectivec/src/test/resources/net/sourceforge/pmd/cpd/NCClient.m
@@ -1,0 +1,5 @@
+@import UIKit;
+
+static SecCertificateRef gNСServerLogonCertificate;
+
+@end


### PR DESCRIPTION
One of our customers uses unicode characters in their Objective-C identifiers. This caused a failure of CPD, because this was not accepted by the grammar. I extended the Objective-C grammar so unicode characters are accepted in identifiers.