### PR TITLE
Removed file filter for files that are explicitly specified on the CPD command line using the '--files' command line option.

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
@@ -105,13 +105,7 @@ public class CPDCommandLineInterface {
 						cpd.addAllInDirectory(file);
 					}
 				} else {
-					//Add a single file if it is accepted by the file filter
-					File directory = file.getAbsoluteFile().getParentFile();
-					String filename = file.getName();
-
-					if (filter.accept(directory, filename)) {
-						cpd.add(file);
-					}
+					cpd.add(file);
 				}
 			}
 		} catch (IOException e) {


### PR DESCRIPTION
At TIOBE we want to use CPD to check duplicated code for TypeScript and XAML with the built-in Ecmascript and JSP tokenizers. The TypeScript syntax resembles Javascript and XAML files are XML files, just as JSP files. 

Unfortunately we cannot use the built-in tokenizers, because CPD rejects the files because the file extensions do not match '.js' or '.jsp'. To fix this problem, I removed the file filter when a user explicit specifies a file name on the CPD command line instead of a directory. I think this is a rare use case, a normal user will specify a directory containing the source files, so it is safe to assume that the user knows what he is doing. 